### PR TITLE
Caching merge

### DIFF
--- a/conda/htrc-feature-reader/meta.yaml
+++ b/conda/htrc-feature-reader/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - pymarc
     - requests
     - rapidjson
-    - bz2file
 
   run:
     - python
@@ -43,7 +42,6 @@ requirements:
     - pymarc
     - requests
     - rapidjson
-    - bz2file
 
 test:
   # Python imports

--- a/examples/Accessing volumes by ids.ipynb
+++ b/examples/Accessing volumes by ids.ipynb
@@ -707,35 +707,151 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cache resolvers\n",
+    "\n",
+    "This logic is extended in the core library to the methods for 'cache_local', 'cache_pairtree', and 'cache_ziptree' that first look locally and then on the internet. These are implemented using a"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 350,
+   "execution_count": 453,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmpdir = tempfile.gettempdir()\n",
+    "\n",
+    "CacheResolver = resolvers.make_cache_resolver(resolvers.PairtreeResolver, resolvers.HttpResolver)\n",
+    "my_resolver = CacheResolver(dir = os.path.join(tmpdir, \"\"), format = \"json\", compression = \"gz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The type of this resolver is pretty ugly!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 449,
    "metadata": {},
    "outputs": [
     {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: '/tmp/tmps6i98bpf/aeu/pairtree_root/ar/k+/=1/39/60/=t/1r/f6/3t/52/ark+=13960=t1rf63t52/aeu.ark+=13960=t1rf63t52.json.gz'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-350-001100948e55>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"aeu.ark:/13960/t1rf63t52\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mresolver2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'rb'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, id, format, id_resolver, default_page_section, path, **kwargs)\u001b[0m\n\u001b[1;32m    414\u001b[0m         \u001b[0;32massert\u001b[0m \u001b[0mformat\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m\"json\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"parquet\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    415\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 416\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparser\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mretrieve_parser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mformat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    417\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    418\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0margs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\u001b[0m in \u001b[0;36mretrieve_parser\u001b[0;34m(id, format, resolver, **kwargs)\u001b[0m\n\u001b[1;32m    336\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"file_handler\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    337\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0mformat\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"json\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 338\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mparsers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mJsonFileHandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    339\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0mformat\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"parquet\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    340\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mparsers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mParquetFileHandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, id, id_resolver, compression, **kwargs)\u001b[0m\n\u001b[1;32m    188\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    189\u001b[0m         \u001b[0;31m# parsing and reading are called here.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 190\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    191\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    192\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moutside_volume\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, id, id_resolver, **kwargs)\u001b[0m\n\u001b[1;32m     91\u001b[0m                 \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 93\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     94\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     95\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_init_resolver\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mformat\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36mparse\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    257\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    258\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 259\u001b[0;31m         \u001b[0mobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_parse_json\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    260\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    261\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_schema\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'features'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'schemaVersion'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36m_parse_json\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    245\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mk\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    246\u001b[0m                 \u001b[0mkwargs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 247\u001b[0;31m         \u001b[0;32mwith\u001b[0m \u001b[0mresolver\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mfin\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    248\u001b[0m             \u001b[0mrawjson\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    249\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(self, id, suffix, format, mode, skip_compression, compression, **kwargs)\u001b[0m\n\u001b[1;32m    148\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    149\u001b[0m         uncompressed = self._open(id = id, suffix = suffix, mode = mode, format = format,\n\u001b[0;32m--> 150\u001b[0;31m                                   **kwargs)\n\u001b[0m\u001b[1;32m    151\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0muncompressed\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    152\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mFileNotFoundError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Empty buffer found very late\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\u001b[0m in \u001b[0;36m_open\u001b[0;34m(self, id, mode, **kwargs)\u001b[0m\n\u001b[1;32m    249\u001b[0m         \u001b[0mfull_path\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mPath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    250\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 251\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfull_path\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    252\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mFileNotFoundError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    253\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstartswith\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'w'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/htrc/lib/python3.6/pathlib.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(self, mode, buffering, encoding, errors, newline)\u001b[0m\n\u001b[1;32m   1181\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_raise_closed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1182\u001b[0m         return io.open(str(self), mode, buffering, encoding, errors, newline,\n\u001b[0;32m-> 1183\u001b[0;31m                        opener=self._opener)\n\u001b[0m\u001b[1;32m   1184\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1185\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mread_bytes\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/htrc/lib/python3.6/pathlib.py\u001b[0m in \u001b[0;36m_opener\u001b[0;34m(self, name, flags, mode)\u001b[0m\n\u001b[1;32m   1035\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_opener\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0o666\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1036\u001b[0m         \u001b[0;31m# A stub for the opener argument to built-in open()\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1037\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_accessor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1038\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1039\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_raw_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0o777\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/miniconda3/envs/htrc/lib/python3.6/pathlib.py\u001b[0m in \u001b[0;36mwrapped\u001b[0;34m(pathobj, *args)\u001b[0m\n\u001b[1;32m    385\u001b[0m         \u001b[0;34m@\u001b[0m\u001b[0mfunctools\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwraps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstrfunc\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    386\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mwrapped\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpathobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 387\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mstrfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpathobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    388\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mstaticmethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwrapped\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    389\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/tmp/tmps6i98bpf/aeu/pairtree_root/ar/k+/=1/39/60/=t/1r/f6/3t/52/ark+=13960=t1rf63t52/aeu.ark+=13960=t1rf63t52.json.gz'"
-     ]
+     "data": {
+      "text/plain": [
+       "htrc_features.resolvers.make_cache_resolver.<locals>.CacheResolver"
+      ]
+     },
+     "execution_count": 449,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "output = Volume(\"aeu.ark:/13960/t1rf63t52\", id_resolver=resolver2, mode = 'rb')"
+    "type(my_resolver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But its behavior is great. You can now download automatically from Hathi. The first occasion takes a while--9 seconds--to pull from the Internet.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 454,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.61 s, sys: 240 ms, total: 2.85 s\n",
+      "Wall time: 9.94 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
+      ],
+      "text/plain": [
+       "<htrc_features.feature_reader.Volume at 0x7f9195a46ef0>"
+      ]
+     },
+     "execution_count": 454,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "Volume(id = \"mdp.39015051692625\", id_resolver = my_resolver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But the next one is quick! Just 500 ms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 455,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 456 ms, sys: 48 ms, total: 504 ms\n",
+      "Wall time: 507 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
+      ],
+      "text/plain": [
+       "<htrc_features.feature_reader.Volume at 0x7f9195a469b0>"
+      ]
+     },
+     "execution_count": 455,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "Volume(id = \"mdp.39015051692625\", id_resolver = my_resolver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 389,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 389,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "isinstance(my_resolver, resolvers.IdResolver)"
    ]
   },
   {

--- a/examples/Accessing volumes by ids.ipynb
+++ b/examples/Accessing volumes by ids.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,8 @@
     "import tempfile\n",
     "import os\n",
     "import json\n",
-    "import logging"
+    "import logging\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -45,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -76,10 +77,10 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f91f44d2b38>"
+       "<htrc_features.feature_reader.Volume at 0x7fde848c6710>"
       ]
      },
-     "execution_count": 228,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -94,6 +95,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tempfile.tempdir"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -104,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -113,10 +123,10 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f91f44ed9e8>"
+       "<htrc_features.feature_reader.Volume at 0x7fde83b69b70>"
       ]
      },
-     "execution_count": 230,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -144,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -225,7 +235,7 @@
        "             MR       NE       1"
       ]
      },
-     "execution_count": 231,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -257,10 +267,10 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f9203511898>"
+       "<htrc_features.feature_reader.Volume at 0x7fde81a87b38>"
       ]
      },
-     "execution_count": 238,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +294,7 @@
        "'\\nNOT IMPLEMENTED: lambda resolution\\n\\nsimple_handler = lambda x: open(\"../data/PZ-volumes/\" + x + \".json.bz2\", mode = \"r\")\\n\\nlocally_resolved_file = Volume(id = \"hvd.hwrqs8\", id_resolver = simple_handler, format = \"json\")\\n\\nlocally_resolved_file\\n\\n'"
       ]
      },
-     "execution_count": 233,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -313,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -394,7 +404,7 @@
        "             MR       NE       1"
       ]
      },
-     "execution_count": 234,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -498,7 +508,7 @@
        " 'b75.zip']"
       ]
      },
-     "execution_count": 241,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -513,12 +523,12 @@
    "source": [
     "## Zipdir reading\n",
     "\n",
-    "Now we can extract"
+    "Now we can extract any individual file from these zipdirs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -527,10 +537,10 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.32044010273894'>The ballet dancer, and On guard,</a></strong> by <em>Serao, Matilde. </em> (1901, 284 pages) - <code>hvd.32044010273894</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f9203511240>"
+       "<htrc_features.feature_reader.Volume at 0x7fde805f7860>"
       ]
      },
-     "execution_count": 242,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -541,49 +551,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fin = resolvers.PairtreeResolver(dir = \"/home/bschmidt/hathi-ef/\", format = \"json\", compression = \"bz2\").open(id = \"hvd.hwrevp\")"
+    "from htrc_features.caching import copy_between_resolvers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's possible to copy from these to some other form of resolution."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<bz2.BZ2File at 0x7f91c3a50390>"
+       "b'{\"id\":\"hvd.32044010273894\",\"metadata\":{\"schemaVersion\":\"1.3\",\"dateCreated\":\"2016-06-18T21:16:55.4637562Z\",\"volumeIdentifier\":\"hvd.32044010273894\",\"accessProfile\":\"google\",\"rightsAttributes\":\"pd\",\"hathitrustRecordNumber\":\"1219987\",\"enumerationChronology\":\" \",\"sourceInstitution\":\"HVD\",\"sourceInstituti'"
       ]
      },
-     "execution_count": 248,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "fin"
+    "pairtree_resolver = resolvers.PairtreeResolver(dir = tempfile.gettempdir(), format = \"json\", compression = \"bz2\")\n",
+    "copy_between_resolvers(\"hvd.32044010273894\", resolvers.ZiptreeResolver(dir = zipdir, compression = \"bz2\", format=\"json\"), pairtree_resolver)\n",
+    "\n",
+    "pairtree_resolver.open(id = \"hvd.32044010273894\").read()[:300]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'schemaVersion': '1.3', 'dateCreated': '2016-06-20T03:50:48.3790146Z', 'volumeIdentifier': 'hvd.hwrevp', 'accessProfile': 'google', 'rightsAttributes': 'pd', 'hathitrustRecordNumber': '11592503', 'enumerationChronology': ' ', 'sourceInstitution': 'HVD', 'sourceInstitutionRecordNumber': '005701721', 'oclc': ['62415828'], 'isbn': [], 'issn': [], 'lccn': [], 'title': 'Annals of the poor. By the Rev. Legh Richmond ...', 'imprint': 'Crocker & Brewster, 1829.', 'lastUpdateDate': '2012-06-04 10:28:09', 'governmentDocument': False, 'pubDate': '1829', 'pubPlace': 'mau', 'language': 'eng', 'bibliographicFormat': 'BK', 'genre': ['not fiction'], 'issuance': 'monographic', 'typeOfResource': 'text', 'classification': {}, 'names': ['Richmond, Legh 1772-1827 ', 'Ayre, John 1801-1869 '], 'htBibUrl': 'http://catalog.hathitrust.org/api/volumes/full/htid/hvd.hwrevp.json', 'handleUrl': 'http://hdl.handle.net/2027/hvd.hwrevp'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(json.loads(fin.read().decode(\"utf-8\"))['metadata'])"
-   ]
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -596,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -605,10 +622,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015028036104'>Russian short stories, ed. for school use,</a></strong> by <em>Schweikert, Harry Christian 1877- ed. </em> (1919, 460 pages) - <code>mdp.39015028036104</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f91c3a7b278>"
+       "<htrc_features.feature_reader.Volume at 0x7fde80723438>"
       ]
      },
-     "execution_count": 253,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -616,33 +633,6 @@
    "source": [
     "v = Volume(id = \"mdp.39015028036104\", dir = Path(project_root, \"data/parquet\"), format = \"parquet\", id_resolver = \"local\")\n",
     "v"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 254,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class ChunkedParquetResolver(htrc_features.parsers.ParquetFileHandler):\n",
-    "    def __init__(self, target, chunk_strategy, **kwargs):\n",
-    "        self.chunk_size = target\n",
-    "        self.chunk_strategy = chunk_strategy\n",
-    "        \n",
-    "        super().__init__(kwargs)\n",
-    "        \n",
-    "    def write(self, volume, meta=True, tokens=True, section_features=False, chars=False, **kwargs):\n",
-    "        \n",
-    "        if meta:\n",
-    "            metastring = BytesIO(json.dumps(volume.parser.meta).encode(\"utf-8\"))\n",
-    "            with self.resolver.open(self.id, **kwargs) as fout:\n",
-    "                fout.write(metastring.read())\n",
-    "        \n",
-    "        if tokens:\n",
-    "            feats = volume.chunked_tokenlist(target = self.chunk_size, strategy = 'ends')\n",
-    "            if not feats.empty:\n",
-    "                with self.resolver.open(id = self.id, suffix = 'tokens') as fout:\n",
-    "                    feats.to_parquet(fout, compression=self.compression)                "
    ]
   },
   {
@@ -658,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 301,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,14 +664,14 @@
    "source": [
     "## 3 resolvers\n",
     "\n",
-    "We'll work with three resolvers at once. It's easy to transition between a variety of different implementations.\n",
+    "Here's a sort of silly example that's part of the test suite. It's easy to transition between a variety of different implementations.\n",
     "\n",
     "This simply read and copy method will be the basis of methods that allow fallback searches and automatic caching."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 335,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,19 +702,39 @@
    "source": [
     "# Cache resolvers\n",
     "\n",
-    "This logic is extended in the core library to the methods for 'cache_local', 'cache_pairtree', and 'cache_ziptree' that first look locally and then on the internet. These are implemented using a"
+    "This logic is extended in the core library to the methods for 'cache_local', 'cache_pairtree', and 'cache_ziptree' that first look locally and then on the internet. These are implemented using a function, make_cache_resolver, that returns a new class constructor. We can make our own between any two resolvers. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 453,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
     "tmpdir = tempfile.gettempdir()\n",
-    "\n",
-    "CacheResolver = resolvers.make_cache_resolver(resolvers.PairtreeResolver, resolvers.HttpResolver)\n",
-    "my_resolver = CacheResolver(dir = os.path.join(tmpdir, \"\"), format = \"json\", compression = \"gz\")"
+    "from htrc_features import caching\n",
+    "CacheResolver = caching.make_fallback_resolver(resolvers.PairtreeResolver, resolvers.HttpResolver(), cache = True)\n",
+    "my_resolver = CacheResolver(dir = os.path.join(tmpdir, \"new_resolution\"), format = \"json\", compression = \"gz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<htrc_features.resolvers.HttpResolver at 0x7fde80722d30>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resolvers.HttpResolver()"
    ]
   },
   {
@@ -736,22 +746,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 449,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "htrc_features.resolvers.make_cache_resolver.<locals>.CacheResolver"
+       "htrc_features.caching.make_fallback_resolver.<locals>.FallbackResolver"
       ]
      },
-     "execution_count": 449,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "type(my_resolver)"
+    "type(my_resolver)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "isinstance(my_resolver, resolvers.IdResolver)"
    ]
   },
   {
@@ -763,15 +793,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 454,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.61 s, sys: 240 ms, total: 2.85 s\n",
-      "Wall time: 9.94 s\n"
+      "CPU times: user 316 ms, sys: 24 ms, total: 340 ms\n",
+      "Wall time: 340 ms\n"
      ]
     },
     {
@@ -780,10 +810,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f9195a46ef0>"
+       "<htrc_features.feature_reader.Volume at 0x7fde80722be0>"
       ]
      },
-     "execution_count": 454,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -803,15 +833,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 455,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 456 ms, sys: 48 ms, total: 504 ms\n",
-      "Wall time: 507 ms\n"
+      "CPU times: user 252 ms, sys: 12 ms, total: 264 ms\n",
+      "Wall time: 260 ms\n"
      ]
     },
     {
@@ -820,10 +850,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f9195a469b0>"
+       "<htrc_features.feature_reader.Volume at 0x7fde80721278>"
       ]
      },
-     "execution_count": 455,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -836,27 +866,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 389,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 389,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Id 'mdp.39015051692625' already in zipfile. Refusing to overwrite\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "Empty buffer found very late",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-26-2f4c587f749a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mnew_ziptree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresolvers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mZiptreeResolver\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtmpdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"new_ziptree\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mformat\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'json'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'w'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mcopy_between_resolvers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mdp.39015051692625\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmy_resolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnew_ziptree\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;31m#copy_between_resolvers(\"mdp.39015051692625\", resolvers.HttpResolver(), zipholder)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-18-969b3ca739ec>\u001b[0m in \u001b[0;36mcopy_between_resolvers\u001b[0;34m(id, resolver1, resolver2)\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0minput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mresolver1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mresolver2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'wb'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(self, volume, **kwargs)\u001b[0m\n\u001b[1;32m    508\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    509\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvolume\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 510\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparser\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvolume\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    511\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    512\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(self, outside_volume, compression, mode, **kwargs)\u001b[0m\n\u001b[1;32m    192\u001b[0m         with self.resolver.open(self.id, compression = self.compression, format = 'json',\n\u001b[1;32m    193\u001b[0m                                 \u001b[0mskip_compression\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mskip_compression\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 194\u001b[0;31m                                 **kwargs) as fout:\n\u001b[0m\u001b[1;32m    195\u001b[0m             \u001b[0mfout\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson_bytestring\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    196\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(self, id, suffix, format, mode, skip_compression, compression, **kwargs)\u001b[0m\n\u001b[1;32m    152\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    153\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0muncompressed\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 154\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mFileNotFoundError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Empty buffer found very late\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    155\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    156\u001b[0m         \u001b[0;31m# The name here is misleading; if mode is 'w', 'decompress' may actually be\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: Empty buffer found very late"
+     ]
     }
    ],
    "source": [
-    "isinstance(my_resolver, resolvers.IdResolver)"
+    "new_ziptree = resolvers.ZiptreeResolver(dir = os.path.join(tmpdir, \"new_ziptree\"), format='json', mode='w')\n",
+    "copy_between_resolvers(\"mdp.39015051692625\", my_resolver, new_ziptree)\n",
+    "#copy_between_resolvers(\"mdp.39015051692625\", resolvers.HttpResolver(), zipholder)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_ziptree.format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parquet_vol = Volume(id = \"mdp.39015051692625\", id_resolver = new_ziptree, format = \"parquet\")\n",
+    "\n",
+    "parquet_vol.tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = new_ziptree.open(\"mdp.39015051692625\", mode = 'rb', suffix = 'tokens')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Volume(id = \"mdp.39015051692625\", id_resolver = \"pairtree_cache\", dir = os.path.join(tmpdir, \"new_pairtree\"), format = \"parquet\").tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,20 +963,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/tests/data/green-gables-15pages.json')"
-      ]
-     },
-     "execution_count": 259,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "Path(project_root, \"tests\", \"data\").iterdir().__next__()"
@@ -886,30 +973,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 363,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<strong><a href='http://hdl.handle.net/2027/uc2.ark:/13960/t1xd0sc6x'>Anne of Green Gables / L.M. Montgomery.</a></strong> by <em>Montgomery, L. M. (Lucy Maud) 1874-1942 </em> (1908, 414 pages) - <code>uc2.ark:/13960/t1xd0sc6x</code>"
-      ],
-      "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f91f729f278>"
-      ]
-     },
-     "execution_count": 363,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Volume(Path(project_root, 'tests/data/green-gables-15pages.json').__str__(), compression = None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 365,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,9 +996,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:htrc]",
+   "display_name": "Python (htrc)",
    "language": "python",
-   "name": "conda-env-htrc-py"
+   "name": "htrc"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/Accessing volumes by ids.ipynb
+++ b/examples/Accessing volumes by ids.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,13 +12,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
     "import htrc_features\n",
     "import htrc_features.resolvers\n",
-    "from htrc_features import Volume, resolvers\n",
+    "from htrc_features import Volume, resolvers, FeatureReader, caching\n",
     "import tempfile\n",
     "import os\n",
     "import json\n",
@@ -72,12 +72,19 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:You have passed a single items to 'ids'or 'paths' in a FeatureReader initialization.Consider calling 'volume' directly.\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16c344d590>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d6a3d8890>"
       ]
      },
      "execution_count": 4,
@@ -91,25 +98,15 @@
     "file_path = Path(pz_root, \"hvd.hwrqs8.json.bz2\").joinpath()\n",
     "file_path = str(file_path)\n",
     "\n",
-    "Volume(file_path)"
+    "FeatureReader(file_path).first()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "None\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(tempfile.tempdir)"
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -122,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -131,16 +128,16 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16c344de50>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d6a3d8550>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Volume(\"hvd.hwrqs8\")"
+    "Volume(\"hvd.hwrqs8\", id_resolver = 'http')"
    ]
   },
   {
@@ -155,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -236,7 +233,7 @@
        "             MR       NE       1"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,6 +241,30 @@
    "source": [
     "vol = Volume(id = \"hvd.hwrqs8\", dir = os.path.join(pz_root), id_resolver = \"local\")\n",
     "vol.tokenlist().head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong><a href='http://hdl.handle.net/2027/uc2.ark:/13960/t1xd0sc6x'>Anne of Green Gables / L.M. Montgomery.</a></strong> by <em>Montgomery, L. M. (Lucy Maud) 1874-1942 </em> (1908, 414 pages) - <code>uc2.ark:/13960/t1xd0sc6x</code>"
+      ],
+      "text/plain": [
+       "<htrc_features.feature_reader.Volume at 0x7f6d6618b350>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p = Path(htrc_features.__file__).parent.parent / 'tests/data/partialparq'\n",
+    "Volume(dir = p, format = 'parquet', id='uc2.ark:/13960/t1xd0sc6x')"
    ]
   },
   {
@@ -268,7 +289,7 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16c0480450>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d661b6850>"
       ]
      },
      "execution_count": 8,
@@ -302,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -383,7 +404,7 @@
        "             MR       NE       1"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -397,6 +418,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -407,11 +435,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_dir = Path(tempfile.tempdir, \"test_zipdir\")\n",
+    "sample_dir = Path(tempfile.gettempdir(), \"test_zipdir\")\n",
     "import shutil\n",
     "if sample_dir.exists():\n",
     "    shutil.rmtree(sample_dir)\n",
@@ -436,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +527,7 @@
        " 'b75.zip']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -628,7 +671,7 @@
        "[40223 rows x 1 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -639,12 +682,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
     "zipdir = tempfile.tempdir + \"/ziptree_abc\"\n",
-    "!rm /tmp/ziptree_abc/*\n",
+    "if Path(zipdir).exists():\n",
+    "    shutil.rmtree(zipdir)\n",
+    "\n",
+    "Path(zipdir).mkdir()\n",
+    "\n",
     "my_resolver = resolvers.ZiptreeResolver(zipdir, format = 'parquet')\n",
     "web_resolver = resolvers.HttpResolver()\n",
     "\n",
@@ -653,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -777,7 +824,7 @@
        "[59936 rows x 1 columns]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -795,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -825,7 +872,7 @@
        "b'{\"id\":\"hvd.32044010273894\",\"metadata\":{\"schemaVersion\":\"1.3\",\"dateCreated\":\"2016-06-18T21:16:55.4637562Z\",\"volumeIdentifier\":\"hvd.32044010273894\",\"accessProfile\":\"google\",\"rightsAttributes\":\"pd\",\"hathitrustRecordNumber\":\"1219987\",\"enumerationChronology\":\" \",\"sourceInstitution\":\"HVD\",\"sourceInstituti'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -858,10 +905,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015028036104'>Russian short stories, ed. for school use,</a></strong> by <em>Schweikert, Harry Christian 1877- ed. </em> (1919, 460 pages) - <code>mdp.39015028036104</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16be2ab650>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d651e0c90>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -884,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -904,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,7 +987,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -966,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -975,7 +1022,7 @@
        "htrc_features.caching.make_fallback_resolver.<locals>.FallbackResolver"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -986,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -995,7 +1042,7 @@
        "True"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1013,15 +1060,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 244 ms, sys: 32 ms, total: 276 ms\n",
-      "Wall time: 276 ms\n"
+      "CPU times: user 3.34 s, sys: 136 ms, total: 3.48 s\n",
+      "Wall time: 13.6 s\n"
      ]
     },
     {
@@ -1030,10 +1077,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16c21d9b10>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d65f73650>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1053,15 +1100,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 244 ms, sys: 24 ms, total: 268 ms\n",
-      "Wall time: 267 ms\n"
+      "CPU times: user 332 ms, sys: 20 ms, total: 352 ms\n",
+      "Wall time: 353 ms\n"
      ]
     },
     {
@@ -1070,10 +1117,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16c062fc10>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d6651ab10>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1093,7 +1140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1108,7 +1155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -1117,7 +1164,7 @@
        "'parquet'"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1128,7 +1175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1250,7 +1297,7 @@
        "[310594 rows x 1 columns]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1277,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1358,19 +1405,13 @@
       "    if (await self.run_code(code, result,  async_=asy)):\n",
       "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 3331, in run_code\n",
       "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
-      "  File \"<ipython-input-29-02049e716688>\", line 1, in <module>\n",
+      "  File \"<ipython-input-43-02049e716688>\", line 1, in <module>\n",
       "    Volume(id = \"mdp.39015051692625\", id_resolver = \"pairtree_cached_http\", dir = os.path.join(tmpdir, \"new_pairtree\"), format = \"parquet\").tokenlist()\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 451, in __init__\n",
-      "    self.parser = retrieve_parser(id, format, resolver, compression, dir, **kwargs)\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 358, in retrieve_parser\n",
-      "    **kwargs)\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 416, in __init__\n",
-      "    super().__init__(id = id, id_resolver = id_resolver, compression = compression, **kwargs)\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 58, in __init__\n",
-      "    self.resolver = self._init_resolver(id_resolver, compression=self.compression, **kwargs)\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 97, in _init_resolver\n",
-      "    return resolver_nicknames[id_resolver](format = format, **kwargs)\n",
-      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\", line 312, in __missing__\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 456, in __init__\n",
+      "    mode = 'rb')\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 356, in create_resolver\n",
+      "    id_resolver = resolvers.resolver_nicknames[id_resolver]\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\", line 321, in __missing__\n",
       "    DeprecationWarning)\n",
       "Message: \"You're creating an exotic resolver; this is undocumentedand unspported, and may be removed in a future version\"\n",
       "Arguments: (<class 'DeprecationWarning'>,)\n"
@@ -1495,7 +1536,7 @@
        "[310594 rows x 1 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1506,7 +1547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1515,7 +1556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -1524,7 +1565,7 @@
        "PosixPath('/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/tests/data/green-gables-15pages.json')"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1536,7 +1577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1545,10 +1586,10 @@
        "<strong><a href='http://hdl.handle.net/2027/uc2.ark:/13960/t1xd0sc6x'>Anne of Green Gables / L.M. Montgomery.</a></strong> by <em>Montgomery, L. M. (Lucy Maud) 1874-1942 </em> (1908, 414 pages) - <code>uc2.ark:/13960/t1xd0sc6x</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7f16be2a7e90>"
+       "<htrc_features.feature_reader.Volume at 0x7f6d66384a10>"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1559,7 +1600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1593,51 +1634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import yaml\n",
-    "s = \"\"\"\n",
-    "-\n",
-    "  id_resolver: ziptree\n",
-    "  dir: /drobo/hathi_ziptree\n",
-    "  format: parquet\n",
-    "  compression: gzip\n",
-    "-\n",
-    "  id_resolver: pairtree\n",
-    "  dir: /drobo/feature-counts\n",
-    "  format: json\n",
-    "  compression: bz2\n",
-    "  cache: false\n",
-    "-\n",
-    "  format: json\n",
-    "  compression: null\n",
-    "  id_resolver: \"http\"\n",
-    "\"\"\"\n",
-    "config = yaml.load(s, yaml.SafeLoader)\n",
-    "\n",
-    "def resolver_factory(id_resolver, **kwargs):\n",
-    "    return htrc_features.resolvers.resolver_nicknames[id_resolver](**kwargs)\n",
-    "\n",
-    "def combine_resolvers(l):\n",
-    "    assert(len(l) >= 2)\n",
-    "    first = l[0]\n",
-    "    rest = l[1:]\n",
-    "    if len(rest) > 1:\n",
-    "        second_choice = combine_resolvers(rest)\n",
-    "    else:\n",
-    "        second_choice = resolver_factory(**rest[0])\n",
-    "    with_fallback = caching.make_fallback_resolver(first['id_resolver'], second_choice, cache = first.get(\"cache\", True))\n",
-    "    del first['id_resolver']\n",
-    "    return with_fallback(**first)\n",
-    "\n",
-    "bens_resolver = combine_resolvers(config)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1662,112 +1659,427 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
        "      <th>count</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>page</th>\n",
-       "      <th>section</th>\n",
        "      <th>token</th>\n",
-       "      <th>pos</th>\n",
        "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <th>body</th>\n",
        "      <th>■^^w^Hm</th>\n",
-       "      <th>NN</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"4\" valign=\"top\">5</th>\n",
-       "      <th rowspan=\"4\" valign=\"top\">body</th>\n",
-       "      <th>,</th>\n",
        "      <th>,</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16-December</th>\n",
-       "      <th>JJ</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1972</th>\n",
-       "      <th>CD</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <th>CD</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <th>...</th>\n",
        "      <th>...</th>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"5\" valign=\"top\">393</th>\n",
-       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
        "      <th>4786</th>\n",
-       "      <th>CD</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9015</th>\n",
-       "      <th>CD</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>MICHIGAN</th>\n",
-       "      <th>NNP</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>OF</th>\n",
-       "      <th>IN</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>UNIVERSITY</th>\n",
-       "      <th>NN</th>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>73743 rows × 1 columns</p>\n",
+       "<p>71223 rows × 1 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                              count\n",
-       "page section token       pos       \n",
-       "3    body    ■^^w^Hm     NN       1\n",
-       "5    body    ,           ,        1\n",
-       "             16-December JJ       1\n",
-       "             1972        CD       1\n",
-       "             2           CD       1\n",
-       "...                             ...\n",
-       "393  body    4786        CD       1\n",
-       "             9015        CD       1\n",
-       "             MICHIGAN    NNP      1\n",
-       "             OF          IN       1\n",
-       "             UNIVERSITY  NN       1\n",
+       "                  count\n",
+       "page token             \n",
+       "3    ■^^w^Hm          1\n",
+       "5    ,                1\n",
+       "     16-December      1\n",
+       "     1972             1\n",
+       "     2                1\n",
+       "...                 ...\n",
+       "393  4786             1\n",
+       "     9015             1\n",
+       "     MICHIGAN         1\n",
+       "     OF               1\n",
+       "     UNIVERSITY       1\n",
        "\n",
-       "[73743 rows x 1 columns]"
+       "[71223 rows x 1 columns]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Volume('mdp.39015012434786', id_resolver = bens_resolver).tokenlist()"
+    "import yaml\n",
+    "s = \"\"\"\n",
+    "-\n",
+    "  id_resolver: local\n",
+    "  dir: /tmp/loc\n",
+    "  format: parquet\n",
+    "  compression: gzip\n",
+    "  token_kwargs:\n",
+    "    drop_section: true\n",
+    "    sections: body\n",
+    "    pos: false\n",
+    "-\n",
+    "  id_resolver: pairtree\n",
+    "  dir: /drobo/feature-counts\n",
+    "  format: json\n",
+    "  compression: bz2\n",
+    "  cache: false\n",
+    "-\n",
+    "  format: json\n",
+    "  compression: null\n",
+    "  id_resolver: \"http\"\n",
+    "\"\"\"\n",
+    "\n",
+    "config = yaml.load(s, yaml.SafeLoader)\n",
+    "p = Path(config[0]['dir'])\n",
+    "if p.exists():\n",
+    "    shutil.rmtree(p)\n",
+    "p.mkdir()\n",
+    "\n",
+    "def resolver_factory(id_resolver, **kwargs):\n",
+    "    return htrc_features.resolvers.resolver_nicknames[id_resolver](**kwargs)\n",
+    "\n",
+    "def combine_resolvers(l):\n",
+    "    assert(len(l) >= 2)\n",
+    "    first = l[0]\n",
+    "    rest = l[1:]\n",
+    "    if len(rest) > 1:\n",
+    "        second_choice = combine_resolvers(rest)\n",
+    "    else:\n",
+    "        second_choice = resolver_factory(**rest[0])\n",
+    "    with_fallback = caching.make_fallback_resolver(first['id_resolver'], second_choice, cache = first.get(\"cache\", True))\n",
+    "    del first['id_resolver']\n",
+    "    return with_fallback(**first)\n",
+    "\n",
+    "\n",
+    "\n",
+    "bens_resolver = combine_resolvers(config)\n",
+    "Volume(id=\"mdp.39015012434786\", id_resolver = bens_resolver).tokenlist(pos=False, section=\"default\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id_resolver': 'local', 'dir': '/tmp/loc', 'format': 'parquet', 'compression': 'gzip', 'token_kwargs': {'drop_section': True, 'sections': 'body', 'pos': False}}\n",
+      "{'id_resolver': 'pairtree', 'dir': '/drobo/feature-counts', 'format': 'json', 'compression': 'bz2', 'cache': False}\n",
+      "{'format': 'json', 'compression': None, 'id_resolver': 'http'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def separate_resolvers(l):\n",
+    "    out = []\n",
+    "    for elem in l:\n",
+    "        print (elem)\n",
+    "        r = htrc_features.resolvers.resolver_nicknames[elem['id_resolver']](**elem)\n",
+    "        out.append(\n",
+    "        r\n",
+    "        )\n",
+    "    return out\n",
+    "config = yaml.load(s, yaml.SafeLoader)\n",
+    "\n",
+    "components = separate_resolvers(config)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "MissingFieldError",
+     "evalue": "Your internal tokenlist representation does not have enough information for the current args. Missing column: pos",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m--------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mMissingFieldError\u001b[0m                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-50-c70ba4b1caba>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"mdp.39015012434786\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbens_resolver\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtokenlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\u001b[0m in \u001b[0;36mtokenlist\u001b[0;34m(self, pages, section, case, pos, page_freq, page_select, drop_section, htid, chunk, overflow_strategy, chunk_target, **kwargs)\u001b[0m\n\u001b[1;32m    707\u001b[0m                 raise MissingFieldError(\"Your internal tokenlist representation does not have \"\n\u001b[1;32m    708\u001b[0m                                         \u001b[0;34m\"enough information for the current args. Missing \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 709\u001b[0;31m                                         \"column: %s\" % column)\n\u001b[0m\u001b[1;32m    710\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    711\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mpage_select\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mMissingFieldError\u001b[0m: Your internal tokenlist representation does not have enough information for the current args. Missing column: pos"
+     ]
+    }
+   ],
+   "source": [
+    "Volume(id=\"mdp.39015012434786\", id_resolver = bens_resolver).tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>token</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <th>■^^w^Hm</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">5</th>\n",
+       "      <th>,</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16-December</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1972</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">393</th>\n",
+       "      <th>4786</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9015</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MICHIGAN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>OF</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>UNIVERSITY</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>71223 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  count\n",
+       "page token             \n",
+       "3    ■^^w^Hm          1\n",
+       "5    ,                1\n",
+       "     16-December      1\n",
+       "     1972             1\n",
+       "     2                1\n",
+       "...                 ...\n",
+       "393  4786             1\n",
+       "     9015             1\n",
+       "     MICHIGAN         1\n",
+       "     OF               1\n",
+       "     UNIVERSITY       1\n",
+       "\n",
+       "[71223 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "#Volume('mdp.39015012434786', id_resolver = components[0]).tokenlist()\n",
+    "copy_between_resolvers('mdp.39015012434786', components[1], components[0])\n",
+    "\n",
+    "pd.read_parquet(p / \"mdp.39015012434786.tokens.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>chunk</th>\n",
+       "      <th>token</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1</th>\n",
+       "      <th>!</th>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>\"</th>\n",
+       "      <td>66</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'S</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'ll</th>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'m</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">16</th>\n",
+       "      <th>yugas</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>—</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>—devotion</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>—supracausal</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>•</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>27070 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    count\n",
+       "chunk token              \n",
+       "1     !                 3\n",
+       "      \"                66\n",
+       "      'S                1\n",
+       "      'll               6\n",
+       "      'm                1\n",
+       "...                   ...\n",
+       "16    yugas             1\n",
+       "      —                 1\n",
+       "      —devotion         1\n",
+       "      —supracausal      1\n",
+       "      •                 1\n",
+       "\n",
+       "[27070 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Volume('mdp.39015012434786', id_resolver = components[1]).tokenlist(chunk = True, pos=False, drop_section= True)"
    ]
   },
   {

--- a/examples/Accessing volumes by ids.ipynb
+++ b/examples/Accessing volumes by ids.ipynb
@@ -77,7 +77,7 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde848c6710>"
+       "<htrc_features.feature_reader.Volume at 0x7f16c344d590>"
       ]
      },
      "execution_count": 4,
@@ -98,9 +98,17 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
    "source": [
-    "tempfile.tempdir"
+    "print(tempfile.tempdir)"
    ]
   },
   {
@@ -123,7 +131,7 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde83b69b70>"
+       "<htrc_features.feature_reader.Volume at 0x7f16c344de50>"
       ]
      },
      "execution_count": 6,
@@ -144,13 +152,6 @@
     "That's basically the entire old method. But you may want to access local objects by their HTIDs. The simplest way to \n",
     "do that is to use the 'local' resolver, which looks in a named directory for an appropriate file. Since the default arguments are 'json' storage with 'bz2' compression, this works with three arguments."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -267,7 +268,7 @@
        "<strong><a href='http://hdl.handle.net/2027/hvd.hwrqs8'>Mr. Rutherford's children. By the authors of \"The wide, wide world,\" \"Queechy,\", \"Dollars and cents,\" etc., etc.</a></strong> by <em>Warner, Susan 1819-1885 ,Orr, John William 1815-1887 engr. ,Warner, Anna Bartlett 1824-1915 joint author. </em> (1855, 278 pages) - <code>hvd.hwrqs8</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde81a87b38>"
+       "<htrc_features.feature_reader.Volume at 0x7f16c0480450>"
       ]
      },
      "execution_count": 8,
@@ -285,32 +286,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nNOT IMPLEMENTED: lambda resolution\\n\\nsimple_handler = lambda x: open(\"../data/PZ-volumes/\" + x + \".json.bz2\", mode = \"r\")\\n\\nlocally_resolved_file = Volume(id = \"hvd.hwrqs8\", id_resolver = simple_handler, format = \"json\")\\n\\nlocally_resolved_file\\n\\n'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "\"\"\"\n",
-    "NOT IMPLEMENTED: lambda resolution\n",
-    "\n",
-    "simple_handler = lambda x: open(\"../data/PZ-volumes/\" + x + \".json.bz2\", mode = \"r\")\n",
-    "\n",
-    "locally_resolved_file = Volume(id = \"hvd.hwrqs8\", id_resolver = simple_handler, format = \"json\")\n",
-    "\n",
-    "locally_resolved_file\n",
-    "\n",
-    "\"\"\""
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -323,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +383,7 @@
        "             MR       NE       1"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,14 +407,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_dir = tempfile.TemporaryDirectory()\n",
-    "zipdir = sample_dir.name\n",
+    "sample_dir = Path(tempfile.tempdir, \"test_zipdir\")\n",
+    "import shutil\n",
+    "if sample_dir.exists():\n",
+    "    shutil.rmtree(sample_dir)\n",
+    "Path.mkdir(sample_dir)\n",
+    "zipdir_1 = str(sample_dir)\n",
     "\n",
-    "zipholder = resolvers.ZiptreeResolver(zipdir, format = \"json\", compression = \"bz2\")\n"
+    "zipholder = resolvers.ZiptreeResolver(zipdir_1, format = \"json\", compression = \"bz2\")\n"
    ]
   },
   {
@@ -445,20 +428,19 @@
     "Now we'll go through the PZ-volumes folder and, for every volume, \n",
     "\n",
     "1. Grab the ID.\n",
-    "2. Read the bzipped binary data into memory\n",
-    "3. Reinsert that binary data into the ziptree holder.\n",
+    "2. Copy from one resolution to the other.\n",
     "\n",
-    "Note that we tell the zipholder to use 'json' storage' and 'bz2' compression. Note that this insertion roundtrip actually decompresses and recompresses the data because of the way that the `IdHandler.open` method works: there are faster ways to insert the binary data directly."
+    "Note that we tell the zipholder to use 'json' storage' and 'bz2' compression. The 'write' method notes the compression equivalence, and\n",
+    "so doesn't waste memory compressing and uncompressing."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "#!rm /tmp/*.zip\n",
-    "\n",
     "\n",
     "ids = set()\n",
     "\n",
@@ -467,13 +449,7 @@
     "for file in os.listdir(pz_root):\n",
     "    if file.endswith(\".bz2\"):\n",
     "        id = htrc_features.utils.extract_htid(file)\n",
-    "        with current_resolver.open(id, format = \"json\", compression = \"bz2\") as original:\n",
-    "            d = original.read()\n",
-    "            try:\n",
-    "                with zipholder.open(id, format = \"json\", compression = \"bz2\", mode = \"wb\") as fout:\n",
-    "                    fout.write(d)\n",
-    "            except KeyError:\n",
-    "                print(\"Already inserted {id}\".format(id=id))        "
+    "        htrc_features.caching.copy_between_resolvers(id, current_resolver, zipholder)"
    ]
   },
   {
@@ -485,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -508,13 +484,13 @@
        " 'b75.zip']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "[z for z in os.listdir(zipdir) if z.endswith(\".zip\")]"
+    "[z for z in os.listdir(zipdir_1) if z.endswith(\".zip\")]"
    ]
   },
   {
@@ -528,30 +504,298 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<strong><a href='http://hdl.handle.net/2027/hvd.32044010273894'>The ballet dancer, and On guard,</a></strong> by <em>Serao, Matilde. </em> (1901, 284 pages) - <code>hvd.32044010273894</code>"
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>section</th>\n",
+       "      <th>token</th>\n",
+       "      <th>pos</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>On</th>\n",
+       "      <th>IN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Serao</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>The</th>\n",
+       "      <th>DT</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>and</th>\n",
+       "      <th>CC</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ballet</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>276</th>\n",
+       "      <th>body</th>\n",
+       "      <th>with</th>\n",
+       "      <th>IN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">283</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">body</th>\n",
+       "      <th>COLLEGE</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CONSERVED</th>\n",
+       "      <th>VBN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>HARVARD</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LIBRARY</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>40223 rows × 1 columns</p>\n",
+       "</div>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde805f7860>"
+       "                            count\n",
+       "page section token     pos       \n",
+       "1    body    On        IN       1\n",
+       "             Serao     NN       1\n",
+       "             The       DT       1\n",
+       "             and       CC       1\n",
+       "             ballet    NN       1\n",
+       "...                           ...\n",
+       "276  body    with      IN       1\n",
+       "283  body    COLLEGE   NNP      1\n",
+       "             CONSERVED VBN      1\n",
+       "             HARVARD   NNP      1\n",
+       "             LIBRARY   NNP      1\n",
+       "\n",
+       "[40223 rows x 1 columns]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Volume(\"hvd.32044010273894\", format = \"json\", compression = \"bz2\", id_resolver = \"ziptree\", dir = zipdir)"
+    "Volume(\"hvd.32044010273894\", format = \"json\", compression = \"bz2\", id_resolver = \"ziptree\", dir = zipdir_1).tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipdir = tempfile.tempdir + \"/ziptree_abc\"\n",
+    "!rm /tmp/ziptree_abc/*\n",
+    "my_resolver = resolvers.ZiptreeResolver(zipdir, format = 'parquet')\n",
+    "web_resolver = resolvers.HttpResolver()\n",
+    "\n",
+    "htrc_features.caching.copy_between_resolvers(\"innd.00000004583746\", web_resolver, my_resolver)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>section</th>\n",
+       "      <th>token</th>\n",
+       "      <th>pos</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">7</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>\"</th>\n",
+       "      <th>''</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>&amp;</th>\n",
+       "      <th>CC</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'HE</th>\n",
+       "      <th>JJ</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'IMORE.</th>\n",
+       "      <th>.</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'agmenta</th>\n",
+       "      <th>.</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">330</th>\n",
+       "      <th rowspan=\"2\" valign=\"top\">body</th>\n",
+       "      <th>wit</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>wrangling</th>\n",
+       "      <th>VBG</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">335</th>\n",
+       "      <th rowspan=\"3\" valign=\"top\">body</th>\n",
+       "      <th>NOTREDAME</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>UNNERSITY</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>c!f</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>59936 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            count\n",
+       "page section token     pos       \n",
+       "7    body    \"         ''       1\n",
+       "             &         CC       1\n",
+       "             'HE       JJ       1\n",
+       "             'IMORE.   .        1\n",
+       "             'agmenta  .        1\n",
+       "...                           ...\n",
+       "330  body    wit       NN       1\n",
+       "             wrangling VBG      1\n",
+       "335  body    NOTREDAME NN       1\n",
+       "             UNNERSITY NNP      1\n",
+       "             c!f       NN       1\n",
+       "\n",
+       "[59936 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Volume(\"innd.00000004583746\", id_resolver = my_resolver).tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Copying between resolvers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,12 +806,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's possible to copy from these to some other form of resolution."
+    "It's possible to copy from these to some other form of resolution. In general, it's fairly easy to subclass 'IdResolver' to whatever way you might like to store files.\n",
+    "\n",
+    "So when you finally get fed up with pairtrees, for instance, you can use your new method here.\n",
+    "\n",
+    "It's generally possible to use the returned filehandles directly. You should be aware, though,\n",
+    "that especially for 'write' methods on resolvers it can occasionally be tricky to handle the locations."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -576,31 +825,18 @@
        "b'{\"id\":\"hvd.32044010273894\",\"metadata\":{\"schemaVersion\":\"1.3\",\"dateCreated\":\"2016-06-18T21:16:55.4637562Z\",\"volumeIdentifier\":\"hvd.32044010273894\",\"accessProfile\":\"google\",\"rightsAttributes\":\"pd\",\"hathitrustRecordNumber\":\"1219987\",\"enumerationChronology\":\" \",\"sourceInstitution\":\"HVD\",\"sourceInstituti'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pairtree_resolver = resolvers.PairtreeResolver(dir = tempfile.gettempdir(), format = \"json\", compression = \"bz2\")\n",
-    "copy_between_resolvers(\"hvd.32044010273894\", resolvers.ZiptreeResolver(dir = zipdir, compression = \"bz2\", format=\"json\"), pairtree_resolver)\n",
+    "pairtree_resolver = resolvers.PairtreeResolver(dir = zipdir_1, format = \"json\", compression = \"bz2\")\n",
+    "\n",
+    "copy_between_resolvers(\"hvd.32044010273894\", resolvers.ZiptreeResolver(dir = zipdir_1, compression = \"bz2\", format=\"json\"), pairtree_resolver)\n",
     "\n",
     "pairtree_resolver.open(id = \"hvd.32044010273894\").read()[:300]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -613,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -622,10 +858,10 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015028036104'>Russian short stories, ed. for school use,</a></strong> by <em>Schweikert, Harry Christian 1877- ed. </em> (1919, 460 pages) - <code>mdp.39015028036104</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde80723438>"
+       "<htrc_features.feature_reader.Volume at 0x7f16be2ab650>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -648,14 +884,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def copy_between_resolvers(id, resolver1, resolver2):\n",
-    "    input = Volume(id, id_resolver=resolver1)\n",
-    "    output = Volume(id, id_resolver=resolver2, mode = 'wb')\n",
-    "    output.write(input)\n"
+    "from htrc_features.caching import copy_between_resolvers"
    ]
   },
   {
@@ -666,12 +899,12 @@
     "\n",
     "Here's a sort of silly example that's part of the test suite. It's easy to transition between a variety of different implementations.\n",
     "\n",
-    "This simply read and copy method will be the basis of methods that allow fallback searches and automatic caching."
+    "This simply read and copy method is the basis of methods that allow fallback searches and automatic caching."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,11 +940,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "tmpdir = tempfile.gettempdir()\n",
+    "tmpdir = tempfile.gettempdir() + \"/neopairtree\"\n",
     "from htrc_features import caching\n",
     "CacheResolver = caching.make_fallback_resolver(resolvers.PairtreeResolver, resolvers.HttpResolver(), cache = True)\n",
     "my_resolver = CacheResolver(dir = os.path.join(tmpdir, \"new_resolution\"), format = \"json\", compression = \"gz\")"
@@ -719,29 +952,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<htrc_features.resolvers.HttpResolver at 0x7fde80722d30>"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "resolvers.HttpResolver()"
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The type of this resolver is pretty ugly!"
+    "The type of the composite resolver, if you look at it, is pretty ugly! It's generated inside a stew of closures and functions."
    ]
   },
   {
@@ -761,7 +981,7 @@
     }
    ],
    "source": [
-    "type(my_resolver)\n"
+    "type(my_resolver)"
    ]
   },
   {
@@ -800,8 +1020,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 316 ms, sys: 24 ms, total: 340 ms\n",
-      "Wall time: 340 ms\n"
+      "CPU times: user 244 ms, sys: 32 ms, total: 276 ms\n",
+      "Wall time: 276 ms\n"
      ]
     },
     {
@@ -810,7 +1030,7 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde80722be0>"
+       "<htrc_features.feature_reader.Volume at 0x7f16c21d9b10>"
       ]
      },
      "execution_count": 24,
@@ -840,8 +1060,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 252 ms, sys: 12 ms, total: 264 ms\n",
-      "Wall time: 260 ms\n"
+      "CPU times: user 244 ms, sys: 24 ms, total: 268 ms\n",
+      "Wall time: 267 ms\n"
      ]
     },
     {
@@ -850,7 +1070,7 @@
        "<strong><a href='http://hdl.handle.net/2027/mdp.39015051692625'>Marāṭhī nāṭyakośa : nāṭaka-raṅgabhūmīvishayaka nivaḍaka māhitī deṇārā grantha / sampādana, Vi. Bhā. Deśapāṇḍe.</a></strong> by <em>Deśapāṇḍe, Vi. Bhā. (Viśvanātha Bhālacandra) 1938- </em> (2000, 1394 pages) - <code>mdp.39015051692625</code>"
       ],
       "text/plain": [
-       "<htrc_features.feature_reader.Volume at 0x7fde80721278>"
+       "<htrc_features.feature_reader.Volume at 0x7f16c062fc10>"
       ]
      },
      "execution_count": 25,
@@ -875,50 +1095,166 @@
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Id 'mdp.39015051692625' already in zipfile. Refusing to overwrite\n"
-     ]
-    },
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "Empty buffer found very late",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-26-2f4c587f749a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mnew_ziptree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresolvers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mZiptreeResolver\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtmpdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"new_ziptree\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mformat\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'json'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'w'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mcopy_between_resolvers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mdp.39015051692625\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmy_resolver\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnew_ziptree\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;31m#copy_between_resolvers(\"mdp.39015051692625\", resolvers.HttpResolver(), zipholder)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-18-969b3ca739ec>\u001b[0m in \u001b[0;36mcopy_between_resolvers\u001b[0;34m(id, resolver1, resolver2)\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0minput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mresolver1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mVolume\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mid_resolver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mresolver2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'wb'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0moutput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(self, volume, **kwargs)\u001b[0m\n\u001b[1;32m    508\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    509\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvolume\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 510\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparser\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvolume\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    511\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    512\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\u001b[0m in \u001b[0;36mwrite\u001b[0;34m(self, outside_volume, compression, mode, **kwargs)\u001b[0m\n\u001b[1;32m    192\u001b[0m         with self.resolver.open(self.id, compression = self.compression, format = 'json',\n\u001b[1;32m    193\u001b[0m                                 \u001b[0mskip_compression\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mskip_compression\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 194\u001b[0;31m                                 **kwargs) as fout:\n\u001b[0m\u001b[1;32m    195\u001b[0m             \u001b[0mfout\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson_bytestring\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    196\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(self, id, suffix, format, mode, skip_compression, compression, **kwargs)\u001b[0m\n\u001b[1;32m    152\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    153\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0muncompressed\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 154\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mFileNotFoundError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Empty buffer found very late\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    155\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    156\u001b[0m         \u001b[0;31m# The name here is misleading; if mode is 'w', 'decompress' may actually be\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: Empty buffer found very late"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "new_ziptree = resolvers.ZiptreeResolver(dir = os.path.join(tmpdir, \"new_ziptree\"), format='json', mode='w')\n",
+    "newtreepath = os.path.join(tmpdir, \"new_ziptree\")\n",
+    "if Path(newtreepath).exists():\n",
+    "    shutil.rmtree(newtreepath)\n",
+    "new_ziptree = resolvers.ZiptreeResolver(dir = newtreepath, format='parquet', mode='w')\n",
+    "\n",
     "copy_between_resolvers(\"mdp.39015051692625\", my_resolver, new_ziptree)\n",
     "#copy_between_resolvers(\"mdp.39015051692625\", resolvers.HttpResolver(), zipholder)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'parquet'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "new_ziptree.format"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>section</th>\n",
+       "      <th>token</th>\n",
+       "      <th>pos</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">2</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>\"</th>\n",
+       "      <th>``</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'</th>\n",
+       "      <th>POS</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(</th>\n",
+       "      <th>-LRB-</th>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>)</th>\n",
+       "      <th>-RRB-</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>)..</th>\n",
+       "      <th>CC</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1394</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>४</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>६</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>७</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>८</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>९</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>310594 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          count\n",
+       "page section token pos         \n",
+       "2    body    \"     ``         2\n",
+       "             '     POS        2\n",
+       "             (     -LRB-      7\n",
+       "             )     -RRB-      1\n",
+       "             )..   CC         1\n",
+       "...                         ...\n",
+       "1394 body    ४     NN         2\n",
+       "             ६     NNP        1\n",
+       "             ७     NN         1\n",
+       "             ८     NNP        2\n",
+       "             ९     NN         2\n",
+       "\n",
+       "[310594 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "parquet_vol = Volume(id = \"mdp.39015051692625\", id_resolver = new_ziptree, format = \"parquet\")\n",
     "\n",
@@ -930,31 +1266,247 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "g = new_ziptree.open(\"mdp.39015051692625\", mode = 'rb', suffix = 'tokens')"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "g.read()"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "--- Logging error ---\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/logging/__init__.py\", line 1025, in emit\n",
+      "    msg = self.format(record)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/logging/__init__.py\", line 869, in format\n",
+      "    return fmt.format(record)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/logging/__init__.py\", line 608, in format\n",
+      "    record.message = record.getMessage()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/logging/__init__.py\", line 369, in getMessage\n",
+      "    msg = msg % self.args\n",
+      "TypeError: not all arguments converted during string formatting\n",
+      "Call stack:\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/runpy.py\", line 193, in _run_module_as_main\n",
+      "    \"__main__\", mod_spec)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/runpy.py\", line 85, in _run_code\n",
+      "    exec(code, run_globals)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel_launcher.py\", line 16, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/traitlets/config/application.py\", line 664, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/kernelapp.py\", line 583, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/platform/asyncio.py\", line 153, in start\n",
+      "    self.asyncio_loop.run_forever()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/asyncio/base_events.py\", line 538, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/asyncio/base_events.py\", line 1782, in _run_once\n",
+      "    handle._run()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/asyncio/events.py\", line 88, in _run\n",
+      "    self._context.run(self._callback, *self._args)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/ioloop.py\", line 690, in <lambda>\n",
+      "    lambda f: self._run_callback(functools.partial(callback, future))\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/ioloop.py\", line 743, in _run_callback\n",
+      "    ret = callback()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 787, in inner\n",
+      "    self.run()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 748, in run\n",
+      "    yielded = self.gen.send(value)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/kernelbase.py\", line 377, in dispatch_queue\n",
+      "    yield self.process_one()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 225, in wrapper\n",
+      "    runner = Runner(result, future, yielded)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 714, in __init__\n",
+      "    self.run()\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 748, in run\n",
+      "    yielded = self.gen.send(value)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/kernelbase.py\", line 361, in process_one\n",
+      "    yield gen.maybe_future(dispatch(*args))\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 209, in wrapper\n",
+      "    yielded = next(result)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/kernelbase.py\", line 268, in dispatch_shell\n",
+      "    yield gen.maybe_future(handler(stream, idents, msg))\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 209, in wrapper\n",
+      "    yielded = next(result)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/kernelbase.py\", line 541, in execute_request\n",
+      "    user_expressions, allow_stdin,\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/tornado/gen.py\", line 209, in wrapper\n",
+      "    yielded = next(result)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/ipkernel.py\", line 300, in do_execute\n",
+      "    res = shell.run_cell(code, store_history=store_history, silent=silent)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/ipykernel/zmqshell.py\", line 536, in run_cell\n",
+      "    return super(ZMQInteractiveShell, self).run_cell(*args, **kwargs)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 2858, in run_cell\n",
+      "    raw_cell, store_history, silent, shell_futures)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 2886, in _run_cell\n",
+      "    return runner(coro)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/async_helpers.py\", line 68, in _pseudo_sync_runner\n",
+      "    coro.send(None)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 3063, in run_cell_async\n",
+      "    interactivity=interactivity, compiler=compiler, result=result)\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 3254, in run_ast_nodes\n",
+      "    if (await self.run_code(code, result,  async_=asy)):\n",
+      "  File \"/home/bschmidt/miniconda3/envs/htrc/lib/python3.7/site-packages/IPython/core/interactiveshell.py\", line 3331, in run_code\n",
+      "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  File \"<ipython-input-29-02049e716688>\", line 1, in <module>\n",
+      "    Volume(id = \"mdp.39015051692625\", id_resolver = \"pairtree_cached_http\", dir = os.path.join(tmpdir, \"new_pairtree\"), format = \"parquet\").tokenlist()\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 451, in __init__\n",
+      "    self.parser = retrieve_parser(id, format, resolver, compression, dir, **kwargs)\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/feature_reader.py\", line 358, in retrieve_parser\n",
+      "    **kwargs)\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 416, in __init__\n",
+      "    super().__init__(id = id, id_resolver = id_resolver, compression = compression, **kwargs)\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 58, in __init__\n",
+      "    self.resolver = self._init_resolver(id_resolver, compression=self.compression, **kwargs)\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/parsers.py\", line 97, in _init_resolver\n",
+      "    return resolver_nicknames[id_resolver](format = format, **kwargs)\n",
+      "  File \"/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/htrc_features/resolvers.py\", line 312, in __missing__\n",
+      "    DeprecationWarning)\n",
+      "Message: \"You're creating an exotic resolver; this is undocumentedand unspported, and may be removed in a future version\"\n",
+      "Arguments: (<class 'DeprecationWarning'>,)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>section</th>\n",
+       "      <th>token</th>\n",
+       "      <th>pos</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">2</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>\"</th>\n",
+       "      <th>``</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>'</th>\n",
+       "      <th>POS</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(</th>\n",
+       "      <th>-LRB-</th>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>)</th>\n",
+       "      <th>-RRB-</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>)..</th>\n",
+       "      <th>CC</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1394</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>४</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>६</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>७</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>८</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>९</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>310594 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          count\n",
+       "page section token pos         \n",
+       "2    body    \"     ``         2\n",
+       "             '     POS        2\n",
+       "             (     -LRB-      7\n",
+       "             )     -RRB-      1\n",
+       "             )..   CC         1\n",
+       "...                         ...\n",
+       "1394 body    ४     NN         2\n",
+       "             ६     NNP        1\n",
+       "             ७     NN         1\n",
+       "             ८     NNP        2\n",
+       "             ९     NN         2\n",
+       "\n",
+       "[310594 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "Volume(id = \"mdp.39015051692625\", id_resolver = \"pairtree_cache\", dir = os.path.join(tmpdir, \"new_pairtree\"), format = \"parquet\").tokenlist()"
+    "Volume(id = \"mdp.39015051692625\", id_resolver = \"pairtree_cached_http\", dir = os.path.join(tmpdir, \"new_pairtree\"), format = \"parquet\").tokenlist()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -963,9 +1515,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/bschmidt/Dropbox/lib/python/htrc-feature-reader/tests/data/green-gables-15pages.json')"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from pathlib import Path\n",
     "Path(project_root, \"tests\", \"data\").iterdir().__next__()"
@@ -973,16 +1536,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<strong><a href='http://hdl.handle.net/2027/uc2.ark:/13960/t1xd0sc6x'>Anne of Green Gables / L.M. Montgomery.</a></strong> by <em>Montgomery, L. M. (Lucy Maud) 1874-1942 </em> (1908, 414 pages) - <code>uc2.ark:/13960/t1xd0sc6x</code>"
+      ],
+      "text/plain": [
+       "<htrc_features.feature_reader.Volume at 0x7f16be2a7e90>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Volume(Path(project_root, 'tests/data/green-gables-15pages.json').__str__(), compression = None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,6 +1569,213 @@
     "testname = resolver2.fname(\"mdp.12345\", format = \"parquet\", compression = \"snappy\", suffix = \"tokens\")\n",
     "assert(testname == \"mdp.12345.tokens.parquet\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Custom configurations\n",
+    "\n",
+    "You can build up resolvers of any length using this\n",
+    "\n",
+    "One convenient way to do so may be to manage configurations using yaml.\n",
+    "\n",
+    "For example, I have the following in ~/.ef-files.yaml.\n",
+    "\n",
+    "The YAML list is, simply, a set of arguments to resolvers.\n",
+    "\n",
+    "1. First I look in a gzip parquet ziptree at /drobo/hathi_ziptree\n",
+    "2. Then I look in the bz2, json feature counts at /drobo/feature-counts. These will be slower, but more complete.\n",
+    "3. Finally, it it's in neither of those places, I go to Hathi's website.\n",
+    "\n",
+    "When it's found, I cache to the parquet ziptree; but **not** to the local file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "s = \"\"\"\n",
+    "-\n",
+    "  id_resolver: ziptree\n",
+    "  dir: /drobo/hathi_ziptree\n",
+    "  format: parquet\n",
+    "  compression: gzip\n",
+    "-\n",
+    "  id_resolver: pairtree\n",
+    "  dir: /drobo/feature-counts\n",
+    "  format: json\n",
+    "  compression: bz2\n",
+    "  cache: false\n",
+    "-\n",
+    "  format: json\n",
+    "  compression: null\n",
+    "  id_resolver: \"http\"\n",
+    "\"\"\"\n",
+    "config = yaml.load(s, yaml.SafeLoader)\n",
+    "\n",
+    "def resolver_factory(id_resolver, **kwargs):\n",
+    "    return htrc_features.resolvers.resolver_nicknames[id_resolver](**kwargs)\n",
+    "\n",
+    "def combine_resolvers(l):\n",
+    "    assert(len(l) >= 2)\n",
+    "    first = l[0]\n",
+    "    rest = l[1:]\n",
+    "    if len(rest) > 1:\n",
+    "        second_choice = combine_resolvers(rest)\n",
+    "    else:\n",
+    "        second_choice = resolver_factory(**rest[0])\n",
+    "    with_fallback = caching.make_fallback_resolver(first['id_resolver'], second_choice, cache = first.get(\"cache\", True))\n",
+    "    del first['id_resolver']\n",
+    "    return with_fallback(**first)\n",
+    "\n",
+    "bens_resolver = combine_resolvers(config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>page</th>\n",
+       "      <th>section</th>\n",
+       "      <th>token</th>\n",
+       "      <th>pos</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <th>body</th>\n",
+       "      <th>■^^w^Hm</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">5</th>\n",
+       "      <th rowspan=\"4\" valign=\"top\">body</th>\n",
+       "      <th>,</th>\n",
+       "      <th>,</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16-December</th>\n",
+       "      <th>JJ</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1972</th>\n",
+       "      <th>CD</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <th>CD</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">393</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">body</th>\n",
+       "      <th>4786</th>\n",
+       "      <th>CD</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9015</th>\n",
+       "      <th>CD</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>MICHIGAN</th>\n",
+       "      <th>NNP</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>OF</th>\n",
+       "      <th>IN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>UNIVERSITY</th>\n",
+       "      <th>NN</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>73743 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                              count\n",
+       "page section token       pos       \n",
+       "3    body    ■^^w^Hm     NN       1\n",
+       "5    body    ,           ,        1\n",
+       "             16-December JJ       1\n",
+       "             1972        CD       1\n",
+       "             2           CD       1\n",
+       "...                             ...\n",
+       "393  body    4786        CD       1\n",
+       "             9015        CD       1\n",
+       "             MICHIGAN    NNP      1\n",
+       "             OF          IN       1\n",
+       "             UNIVERSITY  NN       1\n",
+       "\n",
+       "[73743 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Volume('mdp.39015012434786', id_resolver = bens_resolver).tokenlist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1010,7 +1794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/htrc_features/caching.py
+++ b/htrc_features/caching.py
@@ -6,19 +6,19 @@ from htrc_features.parsers import MissingDataError
 from .resolvers import resolver_nicknames
 
 def copy_between_resolvers(id, resolver1, resolver2):
+#    print (resolver1, "--->", resolver2)
     input = Volume(id, id_resolver=resolver1)
     output = Volume(id, id_resolver=resolver2, mode = 'wb')
     output.write(input)
     
 def make_fallback_resolver(preferred, fallback = None, cache = True):
     """
+
     A function to return a constructor that uses 
     a cache.
 
     If 'fallback' is None, the actual fallback creation can be handled by the user (usually by
     attaching an IdResolver to self.fallback).
-
-
 
     """
     if preferred in resolver_nicknames:
@@ -35,7 +35,6 @@ def make_fallback_resolver(preferred, fallback = None, cache = True):
         """
 
         def __init__(self, fallback_kwargs = {}, **preferred_args):
-
             if fallback in resolver_nicknames:
                 self.fallback = resolver_nicknames[fallback](**fallback_kwargs)       
             elif isinstance(fallback, resolvers.IdResolver):
@@ -73,20 +72,17 @@ def make_fallback_resolver(preferred, fallback = None, cache = True):
             try:
                 fout = super().open(id, **kwargs)
                 logging.debug("Successfully returning from cache")
-                
-                
                 return fout
             except (MissingDataError, FileNotFoundError) as e:
                 if self.fallback is None:
                     logging.warning("No fallback defined")
                     raise e
                 if not cache:
-                    print(fallback_kwargs)
                     input = Volume(id, id_resolver=self.fallback, **fallback_kwargs)
                     return input.parser.open(id, **fallback_kwargs)
                 else:
                     copy_between_resolvers(id, self.fallback, self.super)
-                    fout = super().open(id, **fallback_kwargs)
+                    fout = super().open(id, **kwargs)
                     logging.debug("Successfully returning from cache")
                     return fout           
             

--- a/htrc_features/caching.py
+++ b/htrc_features/caching.py
@@ -1,0 +1,83 @@
+import htrc_features.resolvers as resolvers
+import logging
+
+from htrc_features.feature_reader import Volume
+from htrc_features.parsers import MissingDataError
+from .resolvers import resolver_nicknames
+
+def copy_between_resolvers(id, resolver1, resolver2):
+
+    from htrc_features.feature_reader import Volume    
+    
+    input = Volume(id, id_resolver=resolver1)
+    output = Volume(id, id_resolver=resolver2, mode = 'wb')
+    output.write(input)
+    
+def make_fallback_resolver(preferred, fallback = None, cache = True):
+    """
+    A function to return a constructor that uses 
+    a cache.
+
+    If 'fallback' is None, the actual fallback creation can be handled by the user (usually by
+    attaching an IdResolver to self.fallback).
+
+    """
+    
+    class FallbackResolver(preferred):
+
+        """
+        A cache resolver is a resolver that uses either of two methods.
+
+        It's called with the constructors of both arguments. If you have options
+        for the fallback, they must be passed as dict in the first argument; 
+        then the rest of the args are passed as normal.
+        """
+
+        def __init__(self, fallback_kwargs = {}, **preferred_args):
+
+            if fallback in resolver_nicknames:
+                self.fallback = resolver_nicknames[fallback](**fallback_kwargs)       
+            elif isinstance(fallback, resolvers.IdResolver):
+                self.fallback = fallback
+            elif issubclass(fallback, resolvers.IdResolver):
+                self.fallback = fallback(**fallback_kwargs)
+            elif self.fallback is None:
+                self.fallback = None
+            else:
+                raise TypeError("You must pass an id_resolver to do fallback searches.")
+
+            
+            super().__init__(**preferred_args)            
+
+        def open(self, id, fallback_kwargs = {}, **kwargs):
+
+
+            
+            """
+            Open a file with a fallback method.
+            """
+            
+            try:
+                fout = super().open(id, **kwargs)
+                logging.debug("Successfully returning from cache")
+                return fout
+            except (MissingDataError, FileNotFoundError) as e:
+                if self.fallback is None:
+                    logging.warning("No fallback defined")
+                    raise e
+                
+                input = Volume(id, id_resolver=self.fallback, **fallback_kwargs)
+
+                if not cache:
+                    return input.parser.open(id, **kwargs)
+
+                kwargs['mode'] = 'wb'
+                output = Volume(id, id_resolver=self, **kwargs)
+                output.write(input, **kwargs)
+                logging.debug("Successfully wrote to cache; now returning from there.")
+
+                kwargs['mode'] = 'rb'
+                return super().open(id, **kwargs)
+            
+    return FallbackResolver
+

--- a/htrc_features/caching.py
+++ b/htrc_features/caching.py
@@ -22,6 +22,10 @@ def make_fallback_resolver(preferred, fallback = None, cache = True):
     attaching an IdResolver to self.fallback).
 
     """
+    if preferred in resolver_nicknames:
+        preferred = resolver_nicknames[preferred]
+        
+#    print(issubclass(preferred, resolvers.IdResolver))
     
     class FallbackResolver(preferred):
 
@@ -50,8 +54,6 @@ def make_fallback_resolver(preferred, fallback = None, cache = True):
             super().__init__(**preferred_args)            
 
         def open(self, id, fallback_kwargs = {}, **kwargs):
-
-
             
             """
             Open a file with a fallback method.

--- a/htrc_features/feature_reader.py
+++ b/htrc_features/feature_reader.py
@@ -652,7 +652,8 @@ class Volume(object):
         if chunk:
             return self._chunked_tokenlist(section=section, case=case, pos=pos,
                   page_freq=page_freq, page_select=page_select, drop_section=drop_section,
-                                           htid=htid)
+                                           htid=htid, overflow_strategy = overflow_strategy,
+                                           chunk_target = chunk_target)
         # Create the internal representation if it does not already
         # exist. This will only need to exist once
         if self._tokencounts.empty:

--- a/htrc_features/feature_reader.py
+++ b/htrc_features/feature_reader.py
@@ -604,7 +604,7 @@ class Volume(object):
 
     def tokenlist(self, pages=True, section='default', case=True, pos=True,
                   page_freq=False, page_select=False, drop_section=False,
-                  htid=False, chunk = False, **kwargs):
+                  htid=False, chunk = False, overflow_strategy="ends", chunk_target = 10000, **kwargs):
 
         ''' Get or set tokencounts DataFrame
 

--- a/htrc_features/feature_reader.py
+++ b/htrc_features/feature_reader.py
@@ -392,6 +392,9 @@ class Volume(object):
         self._section_features = pd.DataFrame()
         self._extra_metadata = None
 
+        if "resolver" in kwargs:
+            raise NameError("Caught 'resolver' arg: did you mean to pass 'id_resolver'?")
+        
         if id == False:
             warnings.warn("Please use None to indicate lack of an id", DeprecationWarning)
             id = None
@@ -753,7 +756,7 @@ class Volume(object):
             newindex = ['chunk', 'pstart', 'pend'] + newindex[1:]
 
         # WTF with the index order here.
-        return return_val.set_index(newindex)
+        return return_val.set_index(newindex).sort_index()
 
     def term_volume_freqs(self, page_freq=True, pos=True, case=True):
         ''' Return a list of each term's frequency in the entire volume '''
@@ -845,11 +848,8 @@ class Volume(object):
             if compression == 'default':
                 compression = 'snappy'
 
-        print(self.id)
-        print(id_resolver.mode)
         parser = parsers.ParquetFileHandler(id = self.id, id_resolver = id_resolver,
                                             dir = dir, compression = compression)
-        print(parser.mode)
         parser.write(volume = self, meta = meta, tokens = tokens, chars = chars, section_features = section_features,
                      chunked = chunked, token_kwargs = token_kwargs)
     

--- a/htrc_features/parsers.py
+++ b/htrc_features/parsers.py
@@ -12,20 +12,18 @@ from six import iteritems, StringIO, BytesIO
 import codecs
 import os
 import types
-
-from htrc_features import utils, resolvers
+import bz2
 
 try:
-    import ujson as json
+    import rapidjson as json
 except ImportError:
     import json
+
 import requests
 
 
-import htrc_features.resolvers
-from htrc_features.resolvers import resolver_nicknames
-
-import bz2
+from . import utils, resolvers
+from .resolvers import resolver_nicknames
 
 SECREF = ['header', 'body', 'footer']
 
@@ -98,12 +96,14 @@ class BaseFileHandler(object):
                 
             return Dummy()
             
-        else:
+        elif isinstance(id_resolver, str):
             try:
                 return resolver_nicknames[id_resolver](format = format, **kwargs)
             except KeyError:
-                raise TypeError("""Id resolver must be a function, htrc_features.IdResolver, or
+                raise TypeError("""Id resolver strings must be
                 one of the strings {}""".format(", ".join(list(resolver_nicknames.keys()))))
+        raise TypeError("""Id resolver must be a function, htrc_features.IdResolver, or
+        one of the strings {}""".format(", ".join(list(resolver_nicknames.keys()))))            
 
     def parse(self, **kwargs):
         '''

--- a/htrc_features/parsers.py
+++ b/htrc_features/parsers.py
@@ -420,7 +420,6 @@ class ParquetFileHandler(BaseFileHandler):
                 self.meta = json.loads(meta_buffer.read().decode("utf-8"))
         except:
             self.meta = dict(id=self.id, title=self.id)
-
             
         if not self.meta['id']:
             self.meta['id'] = htrc_features.utils.extract_htid(self.id)

--- a/htrc_features/parsers.py
+++ b/htrc_features/parsers.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
 
-import sys
-PY3 = (sys.version_info[0] >= 3)
-
 import warnings
 import logging
 import pandas as pd
@@ -20,7 +17,6 @@ except ImportError:
     import json
 
 import requests
-
 
 from . import utils, resolvers
 from .resolvers import resolver_nicknames
@@ -172,7 +168,7 @@ class JsonFileHandler(BaseFileHandler):
 
         # parsing and reading are called here.
         super().__init__(id, id_resolver = id_resolver, compression = compression, **kwargs)
-
+        
     
     def write(self, outside_volume, compression='default', mode='wb', **kwargs):
 
@@ -411,6 +407,9 @@ class ParquetFileHandler(BaseFileHandler):
         self.compression = compression
         self.resolver = id_resolver
         self.mode = mode
+
+        if self.resolver == "ziptree" or isinstance(self.resolver, resolvers.ZiptreeResolver):
+            raise NotImplementedError("Not yet able to store parquet files in zp")
         
         super().__init__(id = id, id_resolver = id_resolver, compression = compression, **kwargs)
     

--- a/htrc_features/resolvers.py
+++ b/htrc_features/resolvers.py
@@ -9,19 +9,19 @@ import logging
 import sys
 from pathlib import Path
 
+
 MINOR_VERSION = (sys.version_info[1])
 
 from urllib.request import urlopen as _urlopen
 from urllib.parse import urlparse as parse_url
 from urllib.error import HTTPError
 
-
 class FauxFile():
     """
     This class is a shim to allow sensible filehandling and errors
     with zipfiles, where on an error both the file *inside* the zip
     and the zipfile itself must be closed. It is only used in that
-    specific case at the moment.
+    specific case.
     """
     def __init__(self, *buffers):
         self.main = buffers[0]
@@ -340,11 +340,12 @@ class ZiptreeResolver(IdResolver):
                 self.zipfile.writestr(self.filename, what)
                 
         return DummyWriter(filename, zipfile)
-    
-if __name__ == "__main__":
-    import sys
-    zipdir, id = sys.argv[1:]
-    resolver = ZiptreeResolver(zipdir)
-    import json
-    import bz2
-    v = resolver.get(id).read()
+
+resolver_nicknames = {
+    "path": PathResolver,
+    "pairtree": PairtreeResolver,
+    "ziptree": ZiptreeResolver,
+    "local": LocalResolver,
+    "http": HttpResolver}
+
+

--- a/htrc_features/transformations.py
+++ b/htrc_features/transformations.py
@@ -64,9 +64,7 @@ def _chunking_algorithm(page_counts, target, even = False, two_sided = True, pro
 
     two_sided = whether to work from both the front and back simultaneously, or *only* from the front. (to operate from the back, just flip the page counts before sending it to this function.
 
-    procrastinate: whether to leave all chunks intact. 
-    
-
+    procrastinate: whether to leave all chunks intact without rebalancing.
     """
 
     # Register front and back offsets. At the beginning, this is the size of the full page counts;

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,14 @@
+import pytest
+from htrc_features import Volume, MissingDataError, MissingFieldError, resolvers
+from htrc_features.caching import make_fallback_resolver
+import os
+import pandas as pd
+
+
+def copy_between_resolvers(id, resolver1, resolver2):
+    input = Volume(id, id_resolver=resolver1)
+    output = Volume(id, id_resolver=resolver2, mode = 'wb')
+    output.write(input)
+
+
+

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -56,3 +56,4 @@ class TestChunking():
 
             assert(np.max([*c.values()]) == 500)
 
+    

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,11 +1,36 @@
 from htrc_features.transformations import chunk_ends, chunk_even, chunk_last
+from htrc_features.resolvers import LocalResolver
+from htrc_features import Volume
+from pathlib import Path
 import random
 import numpy as np
 from collections import Counter
-
+import tempfile
+import pandas as pd
 
 class TestChunking():
 
+    def test_write_to_chunked_parquet_sectionless(self):
+        dir = "tests/data"
+        vol_in = Volume(id='aeu.ark:/13960/t1rf63t52', dir = str(dir), id_resolver = 'local')
+        with tempfile.TemporaryDirectory() as test:
+            output = Volume(id='foo.123', format = 'parquet', mode = 'wb', token_kwargs = {"chunk": True,"drop_section": True, "pos":False}, id_resolver='local', dir = test )
+            output.write(vol_in)
+            read = pd.read_parquet(Path(test, "foo.123.tokens.parquet")).reset_index()
+            print(read.columns)
+            assert("chunk" in read.columns)
+    
+    def test_write_to_chunked_parquet(self):
+        dir = "tests/data"
+        vol_in = Volume(id='aeu.ark:/13960/t1rf63t52', dir = str(dir), id_resolver = 'local')
+        with tempfile.TemporaryDirectory() as test:
+            output = Volume(id='foo.123', dir = test, format = 'parquet', mode = 'wb',
+                            token_kwargs = {"chunk": True})
+            output.write(vol_in)
+            read = pd.read_parquet(Path(test, "foo.123.tokens.parquet")).reset_index()
+            print(read.columns)
+            assert("chunk" in read.columns)
+            
     def test_even_chunking(self):
         # All methods should solve it when pages are only one thing long.
         for method in chunk_ends, chunk_even, chunk_last:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -15,7 +15,7 @@ class TestParsing():
         
         with pytest.raises(ValueError):
             # This tries to load the ID from 
-            vol = Volume(id = 'uc2.ark:/13960/t1xd0sc6x', format='json', dir = dir)
+            vol = Volume(id = 'uc2.ark:/13960/t1xd0sc6x', format='json', dir = dir, id_resolver = "http")
         
     def test_full_parquet(self):
         dir = os.path.join('tests', 'data', 'fullparquet')
@@ -110,19 +110,3 @@ class TestParsing():
         assert vol.tokenlist(case=True, pos=False).reset_index().columns.tolist() == ['chunk', 'section', 'token', 'count']
         assert vol.tokenlist().reset_index().columns.tolist() == ['chunk', 'section', 'token', 'pos', 'count']
         assert vol.tokenlist(drop_section=True).reset_index().columns.tolist() == ['chunk', 'token', 'pos', 'count']
-
-# Allow compression formats.
-
-compressions = {
-    'parquet': ['snappy', None, 'gz'],
-    'json': ['bz2', None, 'gz']
-}
-
-for format in ['parquet', 'json']:
-    for compression in compressions[format]:
-        pass
-
-def build_unit_test(format, compression):
-    def my_test(self):
-        p = Volume(id = "aeu.ark:/13960/t1rf63t52", format = "json", compression = "bz2")
-        

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -8,6 +8,7 @@ import pandas as pd
 import tempfile
 from pathlib import Path
 import tempfile
+import pyarrow
 
 project_root = Path(htrc_features.__file__).parent.parent
 
@@ -51,35 +52,34 @@ class TestParsing():
 
                 # Our test assertion ensures that the data has made it all the way through.
                 assert(Volume("aeu.ark:/13960/t1rf63t52", id_resolver = resolver3).tokenlist()['count'].sum() == 97691)
-
+                
     def test_parquet_snappy_resolvers_PairtreeResolver_resolution(self):
         self.combo_test("parquet", resolvers.PairtreeResolver, "snappy")
 
     def test_parquet_snappy_resolvers_ZiptreeResolver_resolution(self):
-        with pytest.raises(NotImplementedError):
-            self.combo_test("parquet", resolvers.ZiptreeResolver, "snappy")
-
+        self.combo_test("parquet", resolvers.ZiptreeResolver, "snappy")
  
     def test_parquet_snappy_resolvers_LocalResolver_resolution(self):
         self.combo_test("parquet", resolvers.LocalResolver, "snappy")
 
- 
     def test_parquet_gz_resolvers_PairtreeResolver_resolution(self):
-        self.combo_test("parquet", resolvers.PairtreeResolver, "gz")
+        self.combo_test("parquet", resolvers.PairtreeResolver, "gzip")
 
+    # If you pass a bad compression format, pandas silently
+    # writes with no compression even though pyarrow raises an exception.
+    # Hmmm.
+#    def test_parquet_gz_resolvers_PairtreeResolver_resolution(self):
+#        with pytest.raises(pyarrow.lib.ArrowException):
+#            self.combo_test("parquet", resolvers.PairtreeResolver, "gz")        
  
     def test_parquet_gz_resolvers_ZiptreeResolver_resolution(self):
-        with pytest.raises(NotImplementedError):        
-            self.combo_test("parquet", resolvers.ZiptreeResolver, "gz")
-
+        self.combo_test("parquet", resolvers.ZiptreeResolver, "gzip")
  
     def test_parquet_gz_resolvers_LocalResolver_resolution(self):
-        self.combo_test("parquet", resolvers.LocalResolver, "gz")
-
+        self.combo_test("parquet", resolvers.LocalResolver, "gzip")
  
     def test_json_gz_resolvers_PairtreeResolver_resolution(self):
         self.combo_test("json", resolvers.PairtreeResolver, "gz")
-
  
     def test_json_gz_resolvers_ZiptreeResolver_resolution(self):
         self.combo_test("json", resolvers.ZiptreeResolver, "gz")
@@ -113,6 +113,7 @@ class TestParsing():
 
     def combo_test(self, format, resolver, compression):
         id = "aeu.ark:/13960/t1rf63t52"
+        print(format, resolver, compression)
         basic_resolver = resolvers.LocalResolver(dir = "tests/data", format="json", compression="bz2")
         with tempfile.TemporaryDirectory() as tempdir:
             testing_resolver_write = resolver(dir = tempdir, format = format, compression = compression)

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,6 +1,7 @@
 import pytest
 from htrc_features.resolvers import IdResolver
 import htrc_features.resolvers as resolvers
+from htrc_features.caching import copy_between_resolvers
 from htrc_features import Volume
 import htrc_features
 import os
@@ -12,12 +13,6 @@ import pyarrow
 
 project_root = Path(htrc_features.__file__).parent.parent
 
-
-def copy_between_resolvers(id, resolver1, resolver2):
-    input = Volume(id, id_resolver=resolver1)
-    output = Volume(id, id_resolver=resolver2, mode = 'wb')
-    output.write(input)
-    
 class TestParsing():
     def test_names(self):
         resolver2 = IdResolver(dir = ".", format = "parquet", compression = "snappy")

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -56,7 +56,8 @@ class TestParsing():
         self.combo_test("parquet", resolvers.PairtreeResolver, "snappy")
 
     def test_parquet_snappy_resolvers_ZiptreeResolver_resolution(self):
-        self.combo_test("parquet", resolvers.ZiptreeResolver, "snappy")
+        with pytest.raises(NotImplementedError):
+            self.combo_test("parquet", resolvers.ZiptreeResolver, "snappy")
 
  
     def test_parquet_snappy_resolvers_LocalResolver_resolution(self):
@@ -68,7 +69,8 @@ class TestParsing():
 
  
     def test_parquet_gz_resolvers_ZiptreeResolver_resolution(self):
-        self.combo_test("parquet", resolvers.ZiptreeResolver, "gz")
+        with pytest.raises(NotImplementedError):        
+            self.combo_test("parquet", resolvers.ZiptreeResolver, "gz")
 
  
     def test_parquet_gz_resolvers_LocalResolver_resolution(self):

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -11,11 +11,12 @@ import tempfile
 
 project_root = Path(htrc_features.__file__).parent.parent
 
+
 def copy_between_resolvers(id, resolver1, resolver2):
     input = Volume(id, id_resolver=resolver1)
     output = Volume(id, id_resolver=resolver2, mode = 'wb')
     output.write(input)
-
+    
 class TestParsing():
     def test_names(self):
         resolver2 = IdResolver(dir = ".", format = "parquet", compression = "snappy")
@@ -49,4 +50,72 @@ class TestParsing():
                 assert(all_files[0].endswith("aeu/pairtree_root/ar/k+/=1/39/60/=t/1r/f6/3t/52/ark+=13960=t1rf63t52/aeu.ark+=13960=t1rf63t52.json.gz"))
 
                 # Our test assertion ensures that the data has made it all the way through.
-                assert(Volume("aeu.ark:/13960/t1rf63t52", id_resolver = resolver3).tokenlist()['count'].sum() == 97691)        
+                assert(Volume("aeu.ark:/13960/t1rf63t52", id_resolver = resolver3).tokenlist()['count'].sum() == 97691)
+
+    def test_parquet_snappy_resolvers_PairtreeResolver_resolution(self):
+        self.combo_test("parquet", resolvers.PairtreeResolver, "snappy")
+
+    def test_parquet_snappy_resolvers_ZiptreeResolver_resolution(self):
+        self.combo_test("parquet", resolvers.ZiptreeResolver, "snappy")
+
+ 
+    def test_parquet_snappy_resolvers_LocalResolver_resolution(self):
+        self.combo_test("parquet", resolvers.LocalResolver, "snappy")
+
+ 
+    def test_parquet_gz_resolvers_PairtreeResolver_resolution(self):
+        self.combo_test("parquet", resolvers.PairtreeResolver, "gz")
+
+ 
+    def test_parquet_gz_resolvers_ZiptreeResolver_resolution(self):
+        self.combo_test("parquet", resolvers.ZiptreeResolver, "gz")
+
+ 
+    def test_parquet_gz_resolvers_LocalResolver_resolution(self):
+        self.combo_test("parquet", resolvers.LocalResolver, "gz")
+
+ 
+    def test_json_gz_resolvers_PairtreeResolver_resolution(self):
+        self.combo_test("json", resolvers.PairtreeResolver, "gz")
+
+ 
+    def test_json_gz_resolvers_ZiptreeResolver_resolution(self):
+        self.combo_test("json", resolvers.ZiptreeResolver, "gz")
+
+ 
+    def test_json_gz_resolvers_LocalResolver_resolution(self):
+        self.combo_test("json", resolvers.LocalResolver, "gz")
+
+ 
+    def test_json_bz2_resolvers_PairtreeResolver_resolution(self):
+        self.combo_test("json", resolvers.PairtreeResolver, "bz2")
+
+ 
+    def test_json_bz2_resolvers_ZiptreeResolver_resolution(self):
+        self.combo_test("json", resolvers.ZiptreeResolver, "bz2")
+
+ 
+    def test_json_bz2_resolvers_LocalResolver_resolution(self):
+        self.combo_test("json", resolvers.LocalResolver, "bz2")
+
+ 
+    def test_json_None_resolvers_PairtreeResolver_resolution(self):
+        self.combo_test("json", resolvers.PairtreeResolver, None)
+
+ 
+    def test_json_None_resolvers_ZiptreeResolver_resolution(self):
+        self.combo_test("json", resolvers.ZiptreeResolver, None)
+
+    def test_json_None_resolvers_LocalResolver_resolution(self):
+        self.combo_test("json", resolvers.LocalResolver, None)
+
+    def combo_test(self, format, resolver, compression):
+        id = "aeu.ark:/13960/t1rf63t52"
+        basic_resolver = resolvers.LocalResolver(dir = "tests/data", format="json", compression="bz2")
+        with tempfile.TemporaryDirectory() as tempdir:
+            testing_resolver_write = resolver(dir = tempdir, format = format, compression = compression)
+            copy_between_resolvers(id, basic_resolver, testing_resolver_write)
+
+            # Test read on a freshly made resolver just in case there's entanglement
+            testing_resolver_read = resolver(dir = tempdir, format = format, compression = compression)            
+            assert(Volume(id, id_resolver = testing_resolver_read).tokenlist()['count'].sum() == 97691)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -248,7 +248,7 @@ class TestVolume():
 
         longest_page = fullvolume.tokenlist().groupby('page').sum().max().iloc[0]
         for chunk_size in [5000, 10000]:
-            chunked = (fullvolume.chunked_tokenlist(chunk_target=chunk_size)
+            chunked = (fullvolume.tokenlist(chunk=True, chunk_target=chunk_size)
                                  .groupby(level='chunk').sum()
                       )
             assert abs(chunked.mean().iloc[0] - chunk_size) < chunk_size/3 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -49,7 +49,7 @@ class TestVolume():
         assert type(vol) == htrc_features.feature_reader.Volume
         
     def test_fullparquet_saving(self, volume, tmp_path):
-        volume.save_parquet(tmp_path, meta=True, tokens=True, chars=True, section_features=True)
+        volume.save(tmp_path, format = "parquet", files = ['meta', 'tokens', 'chars', 'section_features'])
         files = os.listdir(tmp_path)
         for ext in ['meta.json', 'tokens.parquet', 'section.parquet', 'chars.parquet']:
             assert '{}.{}'.format(utils.clean_htid(volume.id), ext) in files
@@ -58,7 +58,7 @@ class TestVolume():
         clean_id = utils.clean_htid(volume.id)
         
         # Save only meta
-        volume.save_parquet(tmp_path, meta=True, tokens=False, chars=False, section_features=False)
+        volume.save(tmp_path, format = 'parquet', files = ['meta'])
         metapath = os.path.join(tmp_path, clean_id+'.meta.json')
         assert os.listdir(tmp_path) == [clean_id+'.meta.json']
         with open(metapath, mode='r') as f:
@@ -67,14 +67,14 @@ class TestVolume():
         os.remove(metapath)
         
         # Save only tokens
-        volume.save_parquet(tmp_path, meta=False, tokens=True, chars=False, section_features=False)
+        volume.save(tmp_path, format = 'parquet', files = ['tokens'])
         assert os.listdir(tmp_path) == [clean_id+'.tokens.parquet']
         os.remove(os.path.join(tmp_path, clean_id+'.tokens.parquet'))
         
     def test_partial_tokenlist_saving(self, volume, tmp_path):
         tkwargs = dict(case=False, pos=False, drop_section=True)
-        volume.save_parquet(tmp_path, meta=False, token_kwargs = tkwargs)
-        
+        volume.save(tmp_path, format='parquet', files = ['tokens'], token_kwargs = tkwargs)
+
         path = os.path.join(tmp_path, os.listdir(tmp_path)[0])
         df = pd.read_parquet(path).reset_index()
         assert (df.columns == ['page', 'lowercase', 'count']).all()


### PR DESCRIPTION
This merge makes the following changes:

1. It adds much more comprehensive tests for a variety of resolvers. All of these pass, although only because I've formally described ziptree storage for parquet files as a NotImplementedError.
2. It sets the default retrieval method for an id on its own  to 'locally_cached_http', and adds a variety of functions for handling resolvers in combination with each other, such as the function caching.copy_between_resolvers and a new set of tricks for building resolvers on the fly that cache between different approaches.
3. It renames "chunked_tokenlist" to "_chunked_tokenlist" and handles the arguments to that function through the catchall `Volume.tokenlist()` method.